### PR TITLE
Fix: fix `runnergroup` flag cannot be recognized due to a typo

### DIFF
--- a/scripts/invoke-ghrunner.ps1
+++ b/scripts/invoke-ghrunner.ps1
@@ -40,7 +40,7 @@ if ($null -ne $labels) {
 }
 if ($null -ne $runner_group) {
     $argList += "--runnergroup"
-    $argList += $runner_group
+    $argList += $runnergroup
 }
 if ($enableupdate -eq $false) {
     $argList += "--disableupdate"

--- a/scripts/invoke-ghrunner.ps1
+++ b/scripts/invoke-ghrunner.ps1
@@ -38,7 +38,7 @@ if ($null -ne $labels) {
     $argList += "--labels"
     $argList += $labels
 }
-if ($null -ne $runner_group) {
+if ($null -ne $runnergroup) {
     $argList += "--runnergroup"
     $argList += $runnergroup
 }


### PR DESCRIPTION
Previously the script using different variable name: `runnergroup` for user input and `runner_group` for inner-script conditions;
Which makes the runner group of windows runners' to be `Default` all time, no matter what we input in flag.

---
![image](https://github.com/fortytwoservices/terraform-azurerm-selfhostedrunnervmss/assets/45203648/e2e0d973-0172-47f1-ba4f-69e5d5123f19)
Tested on our GHES environment. Works correctly.