### PR TITLE
feat: Add support for setting vm os disk storage_account_type through the input variable os_disk_storage_account_type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "self_hosted_runners" {
   }
 
   os_disk {
-    storage_account_type = "Standard_LRS"
+    storage_account_type = var.os_disk_storage_account_type
     caching              = "ReadWrite"
     disk_size_gb         = var.os_disk_size_gb
   }
@@ -209,7 +209,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "self_hosted_runners" {
   }
 
   os_disk {
-    storage_account_type = "Standard_LRS"
+    storage_account_type = var.os_disk_storage_account_type
     caching              = "ReadWrite"
     disk_size_gb         = var.os_disk_size_gb
   }

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "os_disk_size_gb" {
   description = "(Optional) The size of the OS disk in GB. Default is the size of the image used."
 }
 
+variable "os_disk_storage_account_type" {
+  type        = string
+  default     = "Standard_LRS"
+  description = "(Optional) The type of storage account to use for the OS disk. Default is Standard_LRS."
+}
+
 variable "username" {
   type        = string
   default     = "runneradmin"


### PR DESCRIPTION
Signed-off-by: Marius Solbakken Mellum <marius.solbakken@fortytwo.io>